### PR TITLE
Allow defining more than one model package in conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ release.properties
 *.iml
 *.log
 
+
+.DS_Store

--- a/wisdom-orientdb-object/src/main/java/org/wisdom/orientdb/conf/WOrientConf.java
+++ b/wisdom-orientdb-object/src/main/java/org/wisdom/orientdb/conf/WOrientConf.java
@@ -29,16 +29,16 @@ public final class WOrientConf {
     private final String url;
     private final String user;
     private final String pass;
-    private final String nameSpace;
+    private final List<String> nameSpaces;
     private Boolean autolazyloading = true;
     private TXTYPE txtype = TXTYPE.OPTIMISTIC;
 
-    public WOrientConf(String alias, String url, String user, String pass, String nameSpace) {
+    public WOrientConf(String alias, String url, String user, String pass, List<String> nameSpace) {
         this.alias = alias;
         this.url = url;
         this.user = user;
         this.pass = pass;
-        this.nameSpace = nameSpace;
+        this.nameSpaces = nameSpace;
     }
 
     private WOrientConf(String alias, Configuration config) {
@@ -47,9 +47,8 @@ public final class WOrientConf {
             config.getOrDie(ORIENTDB_URL),
             config.getOrDie(ORIENTDB_USER),
             config.getOrDie(ORIENTDB_PASS),
-            config.getOrDie(ORIENTDB_PACKAGE)
+            config.getList(ORIENTDB_PACKAGE)
         );
-
         this.setAutoLazyLoading(config.getBooleanWithDefault(ORIENTDB_AUTOLAZYLOADGING,true));
         this.setTxType(config.get(ORIENTDB_TXTYPE, TXTYPE.class, TXTYPE.OPTIMISTIC));
     }
@@ -70,8 +69,8 @@ public final class WOrientConf {
         return pass;
     }
 
-    public String getNameSpace() {
-        return nameSpace;
+    public List<String> getNameSpace() {
+        return nameSpaces;
     }
 
     public TXTYPE getTxType() {
@@ -103,7 +102,7 @@ public final class WOrientConf {
         dico.put("name",alias);
         dico.put(ORIENTDB_URL,url);
         dico.put(ORIENTDB_USER,user);
-        dico.put(ORIENTDB_PACKAGE,nameSpace);
+        dico.put(ORIENTDB_PACKAGE,nameSpaces);
         dico.put(ORIENTDB_AUTOLAZYLOADGING,autolazyloading);
         dico.put(ORIENTDB_TXTYPE,txtype);
         return dico;
@@ -153,7 +152,7 @@ public final class WOrientConf {
                 "alias='" + alias + '\'' +
                 ", url='" + url + '\'' +
                 ", user='" + user + '\'' +
-                ", nameSpace='" + nameSpace + '\'' +
+                ", nameSpace='" + nameSpaces.toString()+ '\'' +
                 ", autolazyloading=" + autolazyloading + '\'' +
                 ", txtype=" + txtype +
                 '}';

--- a/wisdom-orientdb-object/src/test/java/org/wisdom/orientdb/othermodel/Olleh.java
+++ b/wisdom-orientdb-object/src/test/java/org/wisdom/orientdb/othermodel/Olleh.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014, Technologic Arts Vietnam.
+ * All right reserved.
+ */
+
+package org.wisdom.orientdb.othermodel;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+
+@Entity
+public class Olleh {
+    public String getId() {
+        return id;
+    }
+
+    @Id
+    private String id;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    private String name;
+
+
+    //We override equals and hascode to test value injected in the proxy
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Olleh hello = (Olleh) o;
+
+        if (getId() != null ? !getId().equals(hello.getId()) : hello.getId() != null) return false;
+        return !(getName() != null ? !getName().equals(hello.getName()) : hello.getName() != null);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getId() != null ? getId().hashCode() : 0;
+        result = 31 * result + (getName() != null ? getName().hashCode() : 0);
+        return result;
+    }
+}


### PR DESCRIPTION
exemple : module A use  modulea.models package name to store its OrientDB models, and module B use moduleb.models . Module C require module A and module B and contain the database settings in its application.conf.
With this change we can list package name (comma separated values) in application.conf

I set up a project example ( dumb wisdom-orientdb training) at this link :
https://github.com/remi-parain/wisdom-orientdb-training

Signed-off-by: Rémi Parain
